### PR TITLE
deprecate increments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,6 @@ Intercom.prototype.identify = function(identify) {
   traits = convertDates(traits, formatDate);
 
   // handle options
-  if (opts.increments) traits.increments = opts.increments;
   if (opts.userHash) traits.user_hash = opts.userHash;
   if (opts.user_hash) traits.user_hash = opts.user_hash;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -235,18 +235,6 @@ describe('Intercom', function() {
         });
       });
 
-      it('should allow passing increments', function() {
-        analytics.identify('id', {}, {
-          Intercom: { increments: { number: 42 } }
-        });
-        analytics.called(window.Intercom, 'boot', {
-          app_id: options.appId,
-          user_id: 'id',
-          increments: { number: 42 },
-          id: 'id'
-        });
-      });
-
       it('should send widget settings if the activator isnt the default one.', function() {
         intercom.options.activator = '#my-widget';
         analytics.identify('id');


### PR DESCRIPTION
https://segment.zendesk.com/agent/tickets/40260

intercom deprecated this feature. it has already been removed from our docs. server side integration didn't have this feature to begin with so nothing needs to be done there.