### PR TITLE
map semantic properties

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
     - make
 test:
   override:
-    - make test
+    - make test-sauce

--- a/component.json
+++ b/component.json
@@ -11,7 +11,8 @@
     "avetisk/defaults": "0.0.1",
     "segmentio/obj-case": "0.2.1",
     "segmentio/analytics.js-integration": "^1.0.0",
-    "ianstormtaylor/is": "0.1.0"
+    "ianstormtaylor/is": "0.1.0",
+    "segmentio/extend": "^1.0.0"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var defaults = require('defaults');
 var del = require('obj-case').del;
 var integration = require('analytics.js-integration');
 var is = require('is');
+var extend = require('extend');
 
 /**
  * Expose `Intercom` integration.
@@ -127,7 +128,7 @@ Intercom.prototype.identify = function(identify) {
  */
 
 Intercom.prototype.group = function(group) {
-  var props = group.properties();
+  var props = group.traits({ monthlySpend: 'monthly_spend' });
   props = alias(props, { createdAt: 'created' });
   props = alias(props, { created: 'created_at' });
   var id = group.groupId();
@@ -143,7 +144,7 @@ Intercom.prototype.group = function(group) {
  */
 
 Intercom.prototype.track = function(track) {
-  api('trackEvent', track.event(), track.properties());
+  api('trackEvent', track.event(), formatMetadata(track));
 };
 
 /**
@@ -169,6 +170,32 @@ Intercom.prototype.bootOrUpdate = function(options) {
   api(method, options);
   this.booted = true;
 };
+
+/**
+ * Format properties
+ *
+ * @api private
+ * @param {Object} track
+ * @return {Object} ret
+ */
+
+function formatMetadata(track) {
+  var props = track.properties();
+  var ret = extend(props, {});
+  var revenue = track.revenue();
+  if (revenue) {
+    ret.price = {
+      amount: revenue * 100, // need to be in cents
+      currency: track.currency().toLowerCase() // always fallsback on 'USD'
+    };
+  }
+
+  delete ret.amount;
+  delete ret.currency;
+  delete ret.revenue;
+
+  return ret;
+}
 
 /**
  * Format a date to Intercom's liking.

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ Intercom.prototype.group = function(group) {
   api('update', { company: props });
 };
 
-**
+/**
  * Track.
  *
  * @api public

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ Intercom.prototype.group = function(group) {
   api('update', { company: props });
 };
 
-/**
+**
  * Track.
  *
  * @api public
@@ -183,6 +183,7 @@ function formatMetadata(track) {
   var props = track.properties();
   var ret = extend(props, {});
   var revenue = track.revenue();
+
   if (revenue) {
     ret.price = {
       amount: revenue * 100, // need to be in cents

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -310,6 +310,17 @@ describe('Intercom', function() {
         });
       });
 
+      it('should send monthly spend', function() {
+        analytics.group('id', { name: 'Name', monthlySpend: 10 });
+        analytics.called(window.Intercom, 'update', {
+          company: {
+            id: 'id',
+            name: 'Name',
+            monthly_spend: 10
+          }
+        });
+      });
+
       it('should work with .created_at', function() {
         analytics.group('id', { name: 'Name', createdAt: 'Jan 1, 2000 3:32:33 PM' });
         analytics.called(window.Intercom, 'update', {
@@ -341,6 +352,16 @@ describe('Intercom', function() {
       it('should send an event', function() {
         analytics.track('event');
         analytics.called(window.Intercom, 'trackEvent', 'event', {});
+      });
+
+      it('should properly send price metadata', function() {
+        analytics.track('event', { revenue: 17.38, currency: 'usd' });
+        analytics.called(window.Intercom, 'trackEvent', 'event', {
+          price: {
+            amount: 1738,
+            currency: 'usd'
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
This adds support for looking up `traits.monthlySpend` in `.group()` calls as seen in the server side mapper here: https://github.com/segment-integrations/integration-intercom/blob/master/lib/mapper.js#L84

ref: [intercom docs](https://docs.intercom.io/configuring-for-your-product-or-site/group-your-users-by-company)
This will also add mapping for the price metadata as seen here on server side:

https://github.com/segment-integrations/integration-intercom/blob/master/lib/mapper.js#L189-L198
ref: [intercom docs](https://developers.intercom.io/reference#event-metadata-types)

TODO: Update docs
