### PR TITLE
support hide default launcher

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var defaults = require('@ndhoule/defaults');
 var del = require('obj-case').del;
 var integration = require('@segment/analytics.js-integration');
 var is = require('is-type');
+var extend = require('@ndhoule/extend');
 
 /**
  * Expose `Intercom` integration.
@@ -57,8 +58,9 @@ Intercom.prototype.loaded = function() {
  * @param {Page} page
  */
 
-Intercom.prototype.page = function() {
-  this.bootOrUpdate();
+Intercom.prototype.page = function(page) {
+  var integrationSettings = page.options(this.name);
+  this.bootOrUpdate({}, integrationSettings);
 };
 
 /**
@@ -72,14 +74,14 @@ Intercom.prototype.page = function() {
 
 Intercom.prototype.identify = function(identify) {
   var traits = identify.traits({ userId: 'user_id' });
-  var opts = identify.options(this.name);
+  var integrationSettings = identify.options(this.name);
   var companyCreated = identify.companyCreated();
   var created = identify.created();
   var name = identify.name();
   var id = identify.userId();
   var group = this.analytics.group();
 
-  if (!id && !traits.email) {
+  if (!id && !identify.email()) {
     return;
   }
 
@@ -113,10 +115,10 @@ Intercom.prototype.identify = function(identify) {
   traits = convertDates(traits, formatDate);
 
   // handle options
-  if (opts.userHash) traits.user_hash = opts.userHash;
-  if (opts.user_hash) traits.user_hash = opts.user_hash;
+  if (integrationSettings.userHash) traits.user_hash = integrationSettings.userHash;
+  if (integrationSettings.user_hash) traits.user_hash = integrationSettings.user_hash;
 
-  this.bootOrUpdate(traits);
+  this.bootOrUpdate(traits, integrationSettings);
 };
 
 /**
@@ -135,7 +137,10 @@ Intercom.prototype.group = function(group) {
   props = convertDates(props, formatDate);
   var id = group.groupId();
   if (id) props.id = id;
-  api('update', { company: props });
+  var integrationSettings = group.options(this.name);
+  var traits = extend({ company: props }, hideDefaultLauncher(integrationSettings));
+
+  api('update', traits);
 };
 
 /**
@@ -156,7 +161,7 @@ Intercom.prototype.track = function(track) {
  * @param {Object} options
  */
 
-Intercom.prototype.bootOrUpdate = function(options) {
+Intercom.prototype.bootOrUpdate = function(options, integrationSettings) {
   options = options || {};
   var method = this.booted === true ? 'update' : 'boot';
   var activator = this.options.activator;
@@ -168,6 +173,8 @@ Intercom.prototype.bootOrUpdate = function(options) {
   if (activator !== '#IntercomDefaultWidget') {
     options.widget = { activator: activator };
   }
+  // Check for selective showing of messenger option
+  options = extend(options, hideDefaultLauncher(integrationSettings));
 
   api(method, options);
   this.booted = true;
@@ -194,3 +201,20 @@ function formatDate(date) {
 function api() {
   window.Intercom.apply(window.Intercom, arguments);
 }
+
+/**
+ * Selectively hide messenger
+ * https://docs.intercom.io/configure-intercom-for-your-product-or-site/customize-the-intercom-messenger/customize-the-intercom-messenger-technical#show-the-intercom-messenger-to-selected-users-for-web-
+ * @param {Object} options
+ * @return {Object} ret
+ * @api private
+ */
+
+function hideDefaultLauncher(options) {
+  var ret = {};
+  var setting = options.hideDefaultLauncher;
+  if (setting === undefined || typeof setting !== 'boolean') return ret;
+  ret.hide_default_launcher= setting;
+  return ret;
+}
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-intercom#readme",
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
+    "@ndhoule/extend": "^2.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/convert-dates": "^1.0.0",
     "is-type": "0.0.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -349,5 +349,46 @@ describe('Intercom', function() {
         analytics.called(window.Intercom, 'trackEvent', 'event', {});
       });
     });
+
+    describe('integration settings', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'Intercom');
+      });
+
+      it('page: should set hide_default_launcher if integration setting exists for it', function() {
+        var integrationSettings = {
+          Intercom: { hideDefaultLauncher: true } 
+        };
+        analytics.page({}, integrationSettings);
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId,
+          hide_default_launcher: true
+        });
+      }); 
+
+      it('identify: should set hide_default_launcher if integration setting exists for it', function() {
+        var integrationSettings = {
+          Intercom: { hideDefaultLauncher: true } 
+        };
+        analytics.identify('id', {}, integrationSettings);
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId,
+          user_id: 'id',
+          id: 'id',
+          hide_default_launcher: true
+        });
+      }); 
+
+      it('group: should set hide_default_launcher if integration setting exists for it', function() {
+        var integrationSettings = {
+          Intercom: { hideDefaultLauncher: true } 
+        };
+        analytics.group('id', {}, integrationSettings);
+        analytics.called(window.Intercom, 'update', {
+          company: { id: 'id' },
+          hide_default_launcher: true
+        });
+      }); 
+    });
   });
 });


### PR DESCRIPTION
for: https://segment.atlassian.net/browse/INT-529
docs: https://docs.intercom.io/configure-intercom-for-your-product-or-site/customize-the-intercom-messenger/customize-the-intercom-messenger-technical#show-the-intercom-messenger-to-selected-users-for-web-

basically lets you use Intercom's `hide_default_launcher` option anytime you update the user. This will let them hide the messenger using intercom's native features rather than our existing recommendation of straight up disable a given call via selective integration which is not as good as this since you can still update user/group traits without losing that data inside intercom.

docs pr to go along with it: https://github.com/segmentio/site-docs/pull/1784

@WesleyDRobinson @f2prateek 