### PR TITLE
initialize intercom with segment anonymous_id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -220,7 +220,6 @@ Intercom.prototype.bootOrUpdate = function(options, integrationSettings) {
   var method = this.booted === true ? 'update' : 'boot';
   var activator = this.options.activator;
   options.app_id = this.options.appId;
-  
   // Intercom, will force the widget to appear if the selector is
   // #IntercomDefaultWidget so no need to check inbox, just need to check that
   // the selector isn't #IntercomDefaultWidget.

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,8 +65,9 @@ Intercom.prototype.loaded = function() {
 Intercom.prototype.page = function(page) {
   var integrationSettings = page.options(this.name);
   
-  var method = (this.booted === true && page.obj.name !== '_boot') ? 'update' : 'boot';
-
+  if (page.obj.name === '_boot') {
+    this.booted = false;
+  }
 
   var traits = {};
   

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,12 @@ var Intercom = module.exports = integration('Intercom')
 Intercom.prototype.initialize = function() {
   // Shim out the Intercom library.
   window.Intercom = function() {
+    if (window.analytics &&
+        window.analytics.user() &&
+        window.analytics.user().anonymousId()) {
+      arguments[1]['anonymous_id'] = window.analytics.user().anonymousId();
+    }
+
     window.Intercom.q.push(arguments);
   };
   window.Intercom.q = [];
@@ -200,7 +206,7 @@ Intercom.prototype.bootOrUpdate = function(options, integrationSettings) {
   var method = this.booted === true ? 'update' : 'boot';
   var activator = this.options.activator;
   options.app_id = this.options.appId;
-
+  
   // Intercom, will force the widget to appear if the selector is
   // #IntercomDefaultWidget so no need to check inbox, just need to check that
   // the selector isn't #IntercomDefaultWidget.

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,24 +37,24 @@ var Intercom = module.exports = integration('Intercom')
 Intercom.prototype.initialize = function() {
   // Shim out the Intercom library.
   window.Intercom = function() {
-    if (window.analytics &&
-        window.analytics.user()) {
-        var anonymousId = window.analytics.user().anonymousId();
-        var userId = window.analytics.user().id();
-        var traits = window.analytics.user().traits();
+    if (window.analytics
+        && window.analytics.user()) {
+      var anonymousId = window.analytics.user().anonymousId();
+      var userId = window.analytics.user().id();
+      var traits = window.analytics.user().traits();
 
-        if (anonymousId) {
-            arguments[1]['anonymous_id'] = anonymousId;
-        }
+      if (anonymousId) {
+        arguments[1].anonymous_id = anonymousId;
+      }
 
-        if (userId) {
-            arguments[1]['id'] = userId;
-            arguments[1]['user_id'] = userId;
-        }
+      if (userId) {
+        arguments[1].id = userId;
+        arguments[1].user_id = userId;
+      }
 
-        if (traits && Object.keys(traits).length > 0) {
-            arguments[1] = Object.assign({},arguments[1], traits);
-        }
+      if (traits && Object.keys(traits).length > 0) {
+        arguments[1] = Object.assign({},arguments[1], traits);
+      }
     }
 
     window.Intercom.q.push(arguments);

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,7 +220,7 @@ Intercom.prototype.bootOrUpdate = function(options, integrationSettings) {
   var method = this.booted === true ? 'update' : 'boot';
   var activator = this.options.activator;
   options.app_id = this.options.appId;
-  
+
   // Intercom, will force the widget to appear if the selector is
   // #IntercomDefaultWidget so no need to check inbox, just need to check that
   // the selector isn't #IntercomDefaultWidget.

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,12 +70,13 @@ Intercom.prototype.page = function(page) {
   }
 
   var traits = {};
-  
-  if (window.analytics
-      && window.analytics.user()) {
-    var anonymousId = window.analytics.user().anonymousId();
-    var userId = window.analytics.user().id();
-    var userTraits = window.analytics.user().traits();
+
+  if (this.analytics
+      && this.analytics.user
+      && this.analytics.user()) {
+    var anonymousId = this.analytics.user().anonymousId();
+    var userId = this.analytics.user().id();
+    var userTraits = this.analytics.user().traits();
 
     if (anonymousId) {
       traits.anonymous_id = anonymousId;

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,28 +65,28 @@ Intercom.prototype.loaded = function() {
 Intercom.prototype.page = function(page) {
   var integrationSettings = page.options(this.name);
   
-  var method = this.booted === true ? 'update' : 'boot';
+  var method = (this.booted === true && page.obj.name !== '_boot') ? 'update' : 'boot';
+
 
   var traits = {};
-  if (method === 'boot') {
-    if (window.analytics
-        && window.analytics.user()) {
-      var anonymousId = window.analytics.user().anonymousId();
-      var userId = window.analytics.user().id();
-      var userTraits = window.analytics.user().traits();
+  
+  if (window.analytics
+      && window.analytics.user()) {
+    var anonymousId = window.analytics.user().anonymousId();
+    var userId = window.analytics.user().id();
+    var userTraits = window.analytics.user().traits();
 
-      if (anonymousId) {
-        traits.anonymous_id = anonymousId;
-      }
+    if (anonymousId) {
+      traits.anonymous_id = anonymousId;
+    }
 
-      if (userId) {
-        traits.id = userId;
-        traits.user_id = userId;
-      }
+    if (userId) {
+      traits.id = userId;
+      traits.user_id = userId;
+    }
 
-      if (userTraits && Object.keys(userTraits).length > 0) {
-        traits = Object.assign({},traits, userTraits);
-      }
+    if (userTraits && Object.keys(userTraits).length > 0) {
+      traits = Object.assign({},traits, userTraits);
     }
   }
   

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,26 +37,6 @@ var Intercom = module.exports = integration('Intercom')
 Intercom.prototype.initialize = function() {
   // Shim out the Intercom library.
   window.Intercom = function() {
-    if (window.analytics
-        && window.analytics.user()) {
-      var anonymousId = window.analytics.user().anonymousId();
-      var userId = window.analytics.user().id();
-      var traits = window.analytics.user().traits();
-
-      if (anonymousId) {
-        arguments[1].anonymous_id = anonymousId;
-      }
-
-      if (userId) {
-        arguments[1].id = userId;
-        arguments[1].user_id = userId;
-      }
-
-      if (traits && Object.keys(traits).length > 0) {
-        arguments[1] = Object.assign({},arguments[1], traits);
-      }
-    }
-
     window.Intercom.q.push(arguments);
   };
   window.Intercom.q = [];
@@ -84,7 +64,33 @@ Intercom.prototype.loaded = function() {
 
 Intercom.prototype.page = function(page) {
   var integrationSettings = page.options(this.name);
-  this.bootOrUpdate({}, integrationSettings);
+  
+  var method = this.booted === true ? 'update' : 'boot';
+
+  var traits = {}
+  if (method === 'boot') {
+    if (window.analytics
+        && window.analytics.user()) {
+      var anonymousId = window.analytics.user().anonymousId();
+      var userId = window.analytics.user().id();
+      var userTraits = window.analytics.user().traits();
+
+      if (anonymousId) {
+        traits.anonymous_id = anonymousId;
+      }
+
+      if (userId) {
+        traits.id = userId;
+        traits.user_id = userId;
+      }
+
+      if (userTraits && Object.keys(userTraits).length > 0) {
+        traits = Object.assign({},traits, userTraits);
+      }
+    }
+  }
+  
+  this.bootOrUpdate(traits, integrationSettings);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ Intercom.prototype.page = function(page) {
   
   var method = this.booted === true ? 'update' : 'boot';
 
-  var traits = {}
+  var traits = {};
   if (method === 'boot') {
     if (window.analytics
         && window.analytics.user()) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,9 +39,9 @@ Intercom.prototype.initialize = function() {
   window.Intercom = function() {
     if (window.analytics &&
         window.analytics.user()) {
-        let anonymousId = window.analytics.user().anonymousId();
-        let userId = window.analytics.user().id();
-        let traits = window.analytics.user().traits();
+        var anonymousId = window.analytics.user().anonymousId();
+        var userId = window.analytics.user().id();
+        var traits = window.analytics.user().traits();
 
         if (anonymousId) {
             arguments[1]['anonymous_id'] = anonymousId;

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,6 +220,7 @@ Intercom.prototype.bootOrUpdate = function(options, integrationSettings) {
   var method = this.booted === true ? 'update' : 'boot';
   var activator = this.options.activator;
   options.app_id = this.options.appId;
+  
   // Intercom, will force the widget to appear if the selector is
   // #IntercomDefaultWidget so no need to check inbox, just need to check that
   // the selector isn't #IntercomDefaultWidget.

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,9 +38,23 @@ Intercom.prototype.initialize = function() {
   // Shim out the Intercom library.
   window.Intercom = function() {
     if (window.analytics &&
-        window.analytics.user() &&
-        window.analytics.user().anonymousId()) {
-      arguments[1]['anonymous_id'] = window.analytics.user().anonymousId();
+        window.analytics.user()) {
+        let anonymousId = window.analytics.user().anonymousId();
+        let userId = window.analytics.user().id();
+        let traits = window.analytics.user().traits();
+
+        if (anonymousId) {
+            arguments[1]['anonymous_id'] = anonymousId;
+        }
+
+        if (userId) {
+            arguments[1]['id'] = userId;
+            arguments[1]['user_id'] = userId;
+        }
+
+        if (traits && Object.keys(traits).length > 0) {
+            arguments[1] = Object.assign({},arguments[1], traits);
+        }
     }
 
     window.Intercom.q.push(arguments);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,22 +119,24 @@ describe('Intercom', function() {
       });
 
       describe('page after identify', function() {
-        beforeEach(function () {
-          analytics.stub(analytics, 'user', function () { return {
-            id:function () { return 'id'},
-            anonymousId:function () { return 'anonymousId'},
-            traits:function () { return undefined}
-          }});
+        beforeEach(function() {
+          analytics.stub(analytics, 'user', function() {
+            return {
+              id:function() { return 'id';},
+              anonymousId:function() { return 'anonymousId';},
+              traits:function() { return undefined;}
+            };
+          });
         });
 
         it('should send an id', function() {
-            analytics.page();
-            analytics.called(window.Intercom, 'boot', {
-                app_id: options.appId,
-                id: 'id',
-                user_id: 'id',
-                anonymous_id: "anonymousId"
-            });
+          analytics.page();
+          analytics.called(window.Intercom, 'boot', {
+            app_id: options.appId,
+            id: 'id',
+            user_id: 'id',
+            anonymous_id: 'anonymousId'
+          });
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,7 +26,6 @@ describe('Intercom', function() {
     analytics.use(Intercom);
     analytics.use(tester);
     analytics.add(intercom);
-    window.analytics = undefined;
   });
 
   afterEach(function(done) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,6 +26,7 @@ describe('Intercom', function() {
     analytics.use(Intercom);
     analytics.use(tester);
     analytics.add(intercom);
+    window.analytics = undefined;
   });
 
   afterEach(function(done) {
@@ -86,12 +87,54 @@ describe('Intercom', function() {
       it('should call boot first and update subsequently', function() {
         analytics.page();
         analytics.called(window.Intercom, 'boot', {
-          app_id: options.appId
+          app_id: options.appId,
+          anonymous_id: analytics.user().anonymousId()
         });
 
         analytics.page();
         analytics.called(window.Intercom, 'update', {
-          app_id: options.appId
+          app_id: options.appId,
+          anonymous_id: analytics.user().anonymousId()
+        });
+      });
+
+      it('should call boot if used with _boot', function() {
+        analytics.page();
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId,
+          anonymous_id: analytics.user().anonymousId()
+        });
+
+        analytics.page();
+        analytics.called(window.Intercom, 'update', {
+          app_id: options.appId,
+          anonymous_id: analytics.user().anonymousId()
+        });
+
+        analytics.page('_boot');
+        analytics.calledThrice(window.Intercom, 'boot', {
+          app_id: options.appId,
+          anonymous_id: analytics.user().anonymousId()
+        });
+      });
+
+      describe('page after identify', function() {
+        beforeEach(function () {
+          analytics.stub(analytics, 'user', function () { return {
+            id:function () { return 'id'},
+            anonymousId:function () { return 'anonymousId'},
+            traits:function () { return undefined}
+          }});
+        });
+
+        it('should send an id', function() {
+            analytics.page();
+            analytics.called(window.Intercom, 'boot', {
+                app_id: options.appId,
+                id: 'id',
+                user_id: 'id',
+                anonymous_id: "anonymousId"
+            });
         });
       });
     });
@@ -462,7 +505,8 @@ describe('Intercom', function() {
         analytics.page({}, integrationSettings);
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
-          hide_default_launcher: true
+          hide_default_launcher: true,
+          anonymous_id: analytics.user().anonymousId()
         });
       });
 


### PR DESCRIPTION
fix #30 
another thing is that i think segment intercom integration should check if the user is already identified and initialize with the identified user, currently i don't see how to do it since the user_hash is not persistent.

**EDIT:**
after digging inside the lib i can see that we can also solve #6 as part of this.
the issue is that the intercom integration is not sync with segment user data on multiple cases:
1. if the user not identified its not using the same anonymous id as segment.
2. if the user identified and we open it on another tab without identify again its not using the user data.
3. when the user data is rested intercom integration not doing shutdown and boot again with the new data.

to solve all of this i added new logic that get the user data on each page call in order to be synced with segment user data and also i've added new boot mode (to solve #6) that should be used like that:
```
if (window.analytics) {
    window.analytics.user().reset();
    if (window.Intercom) {
        window.Intercom('shutdown');
    }
    window.analytics.page('_boot');
}
```
